### PR TITLE
Add check for drawing type

### DIFF
--- a/outline_measure.py
+++ b/outline_measure.py
@@ -68,7 +68,6 @@ def getMinMax2DimOfBoard(board):
 
     for draw in board.GetDrawings():
         if type(draw) is pcbnew.DRAWSEGMENT and draw.GetLayerName() == 'Edge.Cuts':
-            print(draw.GetShapeStr().encode('utf_8'));
             if draw.GetShapeStr() == 'Arc':
                 for point in getArcMinMaxPoints(draw):
                     minMax2Dim.updateMinMax(point)

--- a/outline_measure.py
+++ b/outline_measure.py
@@ -1,4 +1,4 @@
-import pcbnew
+from pcbnew import *
 
 class MinMax1DimHolder:
     def __init__(self):
@@ -67,20 +67,22 @@ def getMinMax2DimOfBoard(board):
     minMax2Dim = MinMax2DimHolder()
 
     for draw in board.GetDrawings():
-        if draw.GetLayerName() == 'Edge.Cuts':
-            if draw.GetShapeStr() == 'Arc':
-                for point in getArcMinMaxPoints(draw):
-                    minMax2Dim.updateMinMax(point)
-            elif draw.GetShapeStr() == 'circle':
-                r = draw.GetRadius()
-                center = draw.GetCenter()
-                x = center[0]
-                y = center[1]
-                minMax2Dim.updateMinMax(pcbnew.wxPoint(x + r, y + r))
-                minMax2Dim.updateMinMax(pcbnew.wxPoint(x - r, y - r))
-            else:
-                minMax2Dim.updateMinMax(draw.GetStart())
-                minMax2Dim.updateMinMax(draw.GetEnd())
+        if type(draw) is DRAWSEGMENT:
+            if draw.GetLayerName() == 'Edge.Cuts':
+                print(draw.GetShapeStr().encode('utf_8'));
+                if draw.GetShapeStr() == 'Arc':
+                    for point in getArcMinMaxPoints(draw):
+                        minMax2Dim.updateMinMax(point)
+                elif draw.GetShapeStr() == 'circle':
+                    r = draw.GetRadius()
+                    center = draw.GetCenter()
+                    x = center[0]
+                    y = center[1]
+                    minMax2Dim.updateMinMax(pcbnew.wxPoint(x + r, y + r))
+                    minMax2Dim.updateMinMax(pcbnew.wxPoint(x - r, y - r))
+                else:
+                    minMax2Dim.updateMinMax(draw.GetStart())
+                    minMax2Dim.updateMinMax(draw.GetEnd())
 
     return minMax2Dim
     if minMax2Dim.x.isMinOrMaxNone() or minMax2Dim.y.isMinOrMaxNone():

--- a/outline_measure.py
+++ b/outline_measure.py
@@ -1,4 +1,4 @@
-from pcbnew import *
+import pcbnew
 
 class MinMax1DimHolder:
     def __init__(self):
@@ -67,22 +67,21 @@ def getMinMax2DimOfBoard(board):
     minMax2Dim = MinMax2DimHolder()
 
     for draw in board.GetDrawings():
-        if type(draw) is DRAWSEGMENT:
-            if draw.GetLayerName() == 'Edge.Cuts':
-                print(draw.GetShapeStr().encode('utf_8'));
-                if draw.GetShapeStr() == 'Arc':
-                    for point in getArcMinMaxPoints(draw):
-                        minMax2Dim.updateMinMax(point)
-                elif draw.GetShapeStr() == 'circle':
-                    r = draw.GetRadius()
-                    center = draw.GetCenter()
-                    x = center[0]
-                    y = center[1]
-                    minMax2Dim.updateMinMax(pcbnew.wxPoint(x + r, y + r))
-                    minMax2Dim.updateMinMax(pcbnew.wxPoint(x - r, y - r))
-                else:
-                    minMax2Dim.updateMinMax(draw.GetStart())
-                    minMax2Dim.updateMinMax(draw.GetEnd())
+        if type(draw) is pcbnew.DRAWSEGMENT and draw.GetLayerName() == 'Edge.Cuts':
+            print(draw.GetShapeStr().encode('utf_8'));
+            if draw.GetShapeStr() == 'Arc':
+                for point in getArcMinMaxPoints(draw):
+                    minMax2Dim.updateMinMax(point)
+            elif draw.GetShapeStr() == 'circle':
+                r = draw.GetRadius()
+                center = draw.GetCenter()
+                x = center[0]
+                y = center[1]
+                minMax2Dim.updateMinMax(pcbnew.wxPoint(x + r, y + r))
+                minMax2Dim.updateMinMax(pcbnew.wxPoint(x - r, y - r))
+            else:
+                minMax2Dim.updateMinMax(draw.GetStart())
+                minMax2Dim.updateMinMax(draw.GetEnd())
 
     return minMax2Dim
     if minMax2Dim.x.isMinOrMaxNone() or minMax2Dim.y.isMinOrMaxNone():


### PR DESCRIPTION
こんにちは。

KiCad 5.1.10で実行したところ、エラーが出ました。
修正してみましたのでよろしければマージをお願いします。

■解析状況
【事象】：Exportボタン押下でエラーダイアログが出て処理が止まる
![スクリーンショット 2021-10-01 11 48 46](https://user-images.githubusercontent.com/11240403/135559454-baf4352f-4309-4807-ba1b-4552d72a0f88.png)

【原因】：Shape以外のオブジェクトに対して GetShapeStr()している
KiCadのドキュメントを見ると、GetDrawings()で得られるオブジェクトは図形に限らないようです。
https://docs.kicad.org/5.1/ja/pcbnew/pcbnew.html#board
```python
print "LIST DRAWINGS:"

for item in pcb.GetDrawings():
    if type(item) is TEXTE_PCB:
        print "* Text:    '%s' at %s"%(item.GetText(), item.GetPosition())
    elif type(item) is DRAWSEGMENT:
        print "* Drawing: %s"%item.GetShapeStr() # dir(item)
    else:
        print type(item)
```
今回のエラーも、図形以外のものに対して GetShapeStr()したことで発生しているように見えました。

【修正案】：オブジェクトのタイプをチェックし確実に図形であることを確認する

type(draw) が DRAWSEGMENT かどうかを確認するコードを足したのですが、
DRAWSEGMENTが未定義というエラーが出ました。
![スクリーンショット 2021-10-01 11 44 46](https://user-images.githubusercontent.com/11240403/135560033-9b2a9ac3-4720-4933-936f-438b4183725a.png)
対処として、KiCadサンプルと同様に from ～ でimportするように変更しています。
（もっと良いやり方があるかもしれませんがまずはサンプルに合わせています）

私の環境ではこの修正でエラーは解消しています。

■環境
私の確認環境は次の通りです。
```
Application: KiCad
Version: (5.1.10-1-10_14), release build
Libraries:
    wxWidgets 3.0.4
    libcurl/7.64.1 SecureTransport (LibreSSL/2.8.3) zlib/1.2.11 nghttp2/1.41.0
Platform: macOS Version 10.16 (Build 20G165), 64 bit, Little endian, wxMac
Build Info:
    wxWidgets: 3.0.4 (wchar_t,STL containers,compatible with 2.8)
    Boost: 1.75.0
    OpenCASCADE Technology: 7.5.1
    Curl: 7.54.0
    Compiler: Clang 10.0.1 with C++ ABI 1002

Build settings:
    USE_WX_GRAPHICS_CONTEXT=ON
    USE_WX_OVERLAY=ON
    KICAD_SCRIPTING=ON
    KICAD_SCRIPTING_MODULES=ON
    KICAD_SCRIPTING_PYTHON3=OFF
    KICAD_SCRIPTING_WXPYTHON=ON
    KICAD_SCRIPTING_WXPYTHON_PHOENIX=OFF
    KICAD_SCRIPTING_ACTION_MENU=ON
    BUILD_GITHUB_PLUGIN=ON
    KICAD_USE_OCE=OFF
    KICAD_USE_OCC=ON
    KICAD_SPICE=ON

```