### PR TITLE
Update JLCPCB and fix renaming issue

### DIFF
--- a/gerber_to_order_action.py
+++ b/gerber_to_order_action.py
@@ -206,7 +206,7 @@ def plotLayers(
         for i in range(targetLayerCount):
             plotFilePath = plotFiles[i]
             layerId = layers[i][0]
-            if layerId in layers:
+            if layerId in layerRenameRules:
                 newFileName = layerRenameRules[layerId]
                 newFileName = newFileName.replace('[boardProjectName]', boardProjectName)
                 newFilePath = '%s/%s' % (gerberDirPath, newFileName)

--- a/gerber_to_order_action.py
+++ b/gerber_to_order_action.py
@@ -103,12 +103,12 @@ pcbServices = [
     },
     {
         # https://support.jlcpcb.com/article/22-how-to-generate-the-gerber-files
-        # https://support.jlcpcb.com/article/29-suggested-naming-patterns
+        # https://support.jlcpcb.com/article/149-how-to-generate-gerber-and-drill-files-in-kicad
         'name': 'JLCPCB',
         'useAuxOrigin': False,
         'gerberProtelExtensions': True,
         'excellonFormat': pcbnew.EXCELLON_WRITER.DECIMAL_FORMAT,
-        'drillMergeNpth': True,
+        'drillMergeNpth': False,
         'drillMinimalHeader': False,
         'layerRenameRules': {
             pcbnew.F_Cu:      '[boardProjectName].GTL',
@@ -118,10 +118,10 @@ pcbServices = [
             pcbnew.F_Mask:    '[boardProjectName].GTS',
             pcbnew.B_Mask:    '[boardProjectName].GBS',
             pcbnew.Edge_Cuts: '[boardProjectName].GKO',
-            pcbnew.In1_Cu:    '[boardProjectName].G2L',
-            pcbnew.In2_Cu:    '[boardProjectName].G3L',
+            pcbnew.In1_Cu:    '[boardProjectName].GL2',
+            pcbnew.In2_Cu:    '[boardProjectName].GL3',
         },
-        'drillExtensionRenameTo': 'XLN',
+        'drillExtensionRenameTo': 'TXT',
     },
 ]
 


### PR DESCRIPTION
こんにちは。

JLCPCBのファイル名ルールが古くなっていたようなので最新に対応させました。
また、その際に気づいたのですが、ファイル名の変更処理が動いていませんでした。

asukiaaaさんが１年前に入れられたこの修正 (https://github.com/asukiaaa/gerber_to_order/commit/0d4d4004cc689edfdb2dda158690e27def8931a7) ですが、変数名をtypoしています。
結果的にこの修正以降、ファイル名の変更が全てスキップされています。

ご確認のほどよろしくお願いします。